### PR TITLE
Fixes required

### DIFF
--- a/OpenApi/Builders/Schema.fs
+++ b/OpenApi/Builders/Schema.fs
@@ -87,7 +87,7 @@ type SchemaBuilder () =
 
     [<CustomOperation "required">]
     member _.Required (state: OpenApiSchema, value) =
-        Seq.map state.Required.Add value |> ignore
+        value |> Seq.iter (fun v -> state.Required.Add v |> ignore)
         state
 
     [<CustomOperation "Items">]


### PR DESCRIPTION
Seq.map works lazily if there is no listener, causing value to be not added. Seq.iter solves the problem