### PR TITLE
Add default to SchemaBuilder

### DIFF
--- a/OpenApi/Builders/Schema.fs
+++ b/OpenApi/Builders/Schema.fs
@@ -180,7 +180,7 @@ type SchemaBuilder () =
         state.Reference <- value
         state
 
-    [<CustomOperation "default">]
+    [<CustomOperation "defaultValue">]
     member _.Default (state: OpenApiSchema, value) =
         state.Default <- value
         state

--- a/OpenApi/Builders/Schema.fs
+++ b/OpenApi/Builders/Schema.fs
@@ -179,3 +179,8 @@ type SchemaBuilder () =
     member _.Reference (state: OpenApiSchema, value) =
         state.Reference <- value
         state
+
+    [<CustomOperation "default">]
+    member _.Default (state: OpenApiSchema, value) =
+        state.Default <- value
+        state


### PR DESCRIPTION
I noticed default is missing from SchemaBuilder